### PR TITLE
Update Adventure-Platform-Fabric to latest 1.21.1 compatible version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,10 +12,6 @@ repositories {
     maven("https://maven.impactdev.net/repository/development/")
 
     maven(url = "https://maven.nucleoid.xyz/") { name = "Nucleoid" } // Server GUI
-
-    maven(url = "https://s01.oss.sonatype.org/content/repositories/snapshots/") {
-        name = "sonatype-oss-snapshots" // For MiniMessage snapshot builds
-    }
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
 
     // MiniMessage
     modImplementation(include("net.kyori:adventure-platform-fabric:${property("adventure_platform_version")}")!!)
-    modImplementation(include("net.kyori:adventure-text-minimessage:${property("adventure_text_version")}")!!)
 
     // Server GUI
     modImplementation("eu.pb4:sgui:${property("sgui_version")}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,7 @@ lucko_version=0.3.3
 luckperms_version=5.4
 
 # MiniMessage
-adventure_platform_version=5.9.0
+adventure_platform_version=5.14.2
 adventure_text_version=4.14.0
 
 # ServerGui

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,6 @@ luckperms_version=5.4
 
 # MiniMessage
 adventure_platform_version=5.14.2
-adventure_text_version=4.14.0
 
 # ServerGui
 sgui_version=1.6.1+1.21.1


### PR DESCRIPTION
Adventure-Platform-Fabric 5.9.0 targets Minecraft versions 1.20-1.20.1. The latest stable release for 1.21.1 is 5.14.2.

MiniMessage is bundled with adventure-platform-fabric, so we don't need an explicit dependency on it.

Since 5.14.2 is a release build, we also don't need the sonatype snapshot repository as release builds are present in Maven Central.